### PR TITLE
Changes: check existing gitlab Merge Request issue threads before creating new, get pull request analysis issues instead of branch when sonar scan is done on pull request (sonar.pullrequestKey arg)

### DIFF
--- a/src/main/java/com/talanlabs/sonar/plugins/gitlab/GitLabPlugin.java
+++ b/src/main/java/com/talanlabs/sonar/plugins/gitlab/GitLabPlugin.java
@@ -68,6 +68,7 @@ public class GitLabPlugin implements Plugin {
     public static final String GITLAB_DISABLE_PROXY = "sonar.gitlab.disable_proxy";
     public static final String GITLAB_MERGE_REQUEST_DISCUSSION = "sonar.gitlab.merge_request_discussion";
     public static final String GITLAB_CI_MERGE_REQUEST_IID = "sonar.gitlab.ci_merge_request_iid";
+    public static final String SONAR_PULL_REQUEST_KEY = "sonar.pullrequest.key";
 
     public static final String CATEGORY = "gitlab";
     public static final String SUBCATEGORY = "reporting";

--- a/src/main/java/com/talanlabs/sonar/plugins/gitlab/GitLabPluginConfiguration.java
+++ b/src/main/java/com/talanlabs/sonar/plugins/gitlab/GitLabPluginConfiguration.java
@@ -276,4 +276,9 @@ public class GitLabPluginConfiguration {
         return configuration.getInt(GitLabPlugin.GITLAB_CI_MERGE_REQUEST_IID).orElse(-1);
     }
 
+    public int pullRequestKey() {
+        return configuration.getInt(GitLabPlugin.SONAR_PULL_REQUEST_KEY).orElse(-1);
+    }
+
+
 }

--- a/src/main/java/com/talanlabs/sonar/plugins/gitlab/SonarFacade.java
+++ b/src/main/java/com/talanlabs/sonar/plugins/gitlab/SonarFacade.java
@@ -236,12 +236,13 @@ public class SonarFacade {
 
         String projectKey = reportTaskProps.getProperty("projectKey");
         String refName = gitLabPluginConfiguration.refName();
+        int pullRequestKey = gitLabPluginConfiguration.pullRequestKey();
         int page = 1;
         Integer nbPage = null;
 
         List<Issue> issues = new ArrayList<>();
         while (nbPage == null || page <= nbPage) {
-            Issues.SearchWsResponse searchWsResponse = searchIssues(projectKey, refName, page);
+            Issues.SearchWsResponse searchWsResponse = searchIssues(projectKey, pullRequestKey, refName, page);
             nbPage = computeNbPage(searchWsResponse.getTotal(), searchWsResponse.getPs());
             issues.addAll(toIssues(searchWsResponse, refName));
 
@@ -250,9 +251,12 @@ public class SonarFacade {
         return issues;
     }
 
-    private Issues.SearchWsResponse searchIssues(String componentKey, String branch, int page) {
+    private Issues.SearchWsResponse searchIssues(String componentKey, int pullRequestKey, String branch, int page) {
         SearchRequest searchRequest = new SearchRequest().setComponentKeys(Collections.singletonList(componentKey)).setP(String.valueOf(page)).setResolved("false");
-        if (isNotBlankAndNotEmpty(branch)) {
+        if (pullRequestKey != -1) {
+        	searchRequest.setPullRequest(String.format("%d", pullRequestKey));
+        }
+        else if (isNotBlankAndNotEmpty(branch)) {
             searchRequest.setBranch(branch);
         }
         return wsClient.issues().search(searchRequest);

--- a/src/main/java/com/talanlabs/sonar/plugins/gitlab/api/GitLabAPIMergeRequestDiscussionExt.java
+++ b/src/main/java/com/talanlabs/sonar/plugins/gitlab/api/GitLabAPIMergeRequestDiscussionExt.java
@@ -1,0 +1,124 @@
+/*
+ * SonarQube :: GitLab Plugin
+ * Copyright (C) 2016-2017 Talanlabs
+ * gabriel.allaigre@gmail.com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.talanlabs.sonar.plugins.gitlab.api;
+
+import java.io.IOException;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.sonar.api.utils.log.Logger;
+import org.sonar.api.utils.log.Loggers;
+
+import com.talanlabs.gitlab.api.Paged;
+import com.talanlabs.gitlab.api.v4.GitLabAPI;
+import com.talanlabs.gitlab.api.v4.Pagination;
+import com.talanlabs.gitlab.api.v4.http.Query;
+import com.talanlabs.gitlab.api.v4.utils.QueryHelper;
+
+public class GitLabAPIMergeRequestDiscussionExt {
+
+	private static final Logger LOG = Loggers.get(GitLabAPIMergeRequestDiscussionExt.class);
+
+	private static final String BASE_URL = "/projects/%s/merge_requests/%d/discussions";
+
+	private final GitLabAPI gitLabAPI;
+	static List<GitlabDiscussionStatus> discussions;
+
+	public GitLabAPIMergeRequestDiscussionExt(GitLabAPI gitLabAPI) {
+		this.gitLabAPI = gitLabAPI;
+	}
+
+//
+//    /**
+//     * Gets a list of all discussions for a single merge request.
+//     * <p>
+//     * GET /projects/:id/merge_requests/:merge_request_iid/discussions
+//     *
+//     * @param projectId  (required) - The ID or URL-encoded path of the project
+//     * @param iid        (required) - The IID of a merge request
+//     * @param pagination (optional) - The ID of a discussion
+//     * @return Paged object of {@link GitlabDiscussionStatus} instances
+//     * @throws IOException
+//     */
+	public Paged<GitlabDiscussionStatus> getAllDiscussions(Serializable projectId, Integer iid, Pagination pagination)
+			throws IOException {
+		Query query = QueryHelper.getQuery(pagination);
+		String tailUrl = String.format(BASE_URL + "%s", gitLabAPI.sanitize(projectId), iid, query.build());
+		return gitLabAPI.retrieve().toPaged(tailUrl, GitlabDiscussionStatus[].class);
+	}
+
+	public Boolean hasDiscussion(Integer projectId, Integer mergeRequestIid, String fullPath, Integer lineNumber,
+			String body, String baseSha, String headSha) throws IOException {
+
+		if (discussions == null) {
+
+			LOG.debug("gettting existing Merge Request discussions");
+
+			Paged<GitlabDiscussionStatus> paged = getAllDiscussions(projectId, mergeRequestIid, null);
+
+			do {
+				if (paged.getResults() != null) {
+					if (discussions == null) {
+						discussions = new ArrayList<GitlabDiscussionStatus>();
+					}
+					discussions.addAll(paged.getResults());
+				}
+			} while ((paged = paged.nextPage()) != null);
+		
+
+			if (LOG.isDebugEnabled()) {
+				LOG.debug("Existing count {}", discussions.size());
+				discussions.forEach(item -> {
+					LOG.debug("discussion {} note count {}", item.getId(), item.getNotes().size());
+					item.getNotes().forEach(note -> {
+						GitlabPosition position = note.getPosition();
+						if (position != null) {
+							LOG.debug("-File: {} {}", position.getNewPath(), position.getNewLine());
+							LOG.debug("-bSha: {}, hSha {}", position.getBaseSha(), position.getHeadSha());
+						}
+						LOG.debug("-Note {}: {}",note.getBody().length(), note.getBody());
+					});
+				});
+				
+				LOG.debug("Current Issue Comment:");
+				LOG.debug("Path {} {}", fullPath, lineNumber);
+				LOG.debug("bSha: {}, hSha {}", baseSha, headSha);
+				LOG.debug("Note {}: {}",body.length(), body);
+			}
+		}
+
+		boolean isExist = discussions.stream().anyMatch(x ->
+			x.getNotes().stream().anyMatch(n ->
+				   	body.equals(n.getBody()) 
+				   	&& n.getPosition() != null
+					&& lineNumber.equals(n.getPosition().getNewLine())
+					&& baseSha.equals(n.getPosition().getBaseSha())
+					&& headSha.equals(n.getPosition().getHeadSha())
+					&& fullPath.equals(n.getPosition().getNewPath())
+				)
+			);
+		
+		if(isExist)
+			LOG.debug("-------------------Issue Comment already exist on MR----------------------");
+
+		return isExist;
+	}
+}

--- a/src/main/java/com/talanlabs/sonar/plugins/gitlab/api/GitlabDiscussionStatus.java
+++ b/src/main/java/com/talanlabs/sonar/plugins/gitlab/api/GitlabDiscussionStatus.java
@@ -1,0 +1,60 @@
+/*
+ * SonarQube :: GitLab Plugin
+ * Copyright (C) 2016-2017 Talanlabs
+ * gabriel.allaigre@gmail.com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.talanlabs.sonar.plugins.gitlab.api;
+
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class GitlabDiscussionStatus {
+
+
+    private String id;
+
+    @JsonProperty("individual_note")
+    private boolean individualNote;
+
+    private List<GitlabNote> notes;
+
+	public String getId() {
+		return id;
+	}
+
+	public void setId(String id) {
+		this.id = id;
+	}
+
+	public boolean isIndividualNote() {
+		return individualNote;
+	}
+
+	public void setIndividualNote(boolean individualNote) {
+		this.individualNote = individualNote;
+	}
+
+	public List<GitlabNote> getNotes() {
+		return notes;
+	}
+
+	public void setNotes(List<GitlabNote> notes) {
+		this.notes = notes;
+	}
+    
+}

--- a/src/main/java/com/talanlabs/sonar/plugins/gitlab/api/GitlabNote.java
+++ b/src/main/java/com/talanlabs/sonar/plugins/gitlab/api/GitlabNote.java
@@ -1,0 +1,177 @@
+/*
+ * SonarQube :: GitLab Plugin
+ * Copyright (C) 2016-2017 Talanlabs
+ * gabriel.allaigre@gmail.com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.talanlabs.sonar.plugins.gitlab.api;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.talanlabs.gitlab.api.v4.models.users.GitLabUser;
+import java.util.Date;
+
+public class GitlabNote {
+
+    public static final String URL = "/notes";
+
+    private Integer id;
+    private String body;
+    private String attachment;
+    private GitLabUser author;
+    private boolean system;
+    private boolean upvote;
+    private boolean downvote;
+
+    @JsonProperty("created_at")
+    private Date createdAt;
+
+    private GitlabPosition position;
+
+    @JsonProperty("noteable_id")
+    private Integer noteableId;
+
+    @JsonProperty("noteableType")
+    private String noteable_type;
+
+    private boolean resolvable;
+    private boolean resolved;
+
+    @JsonProperty("resolved_by")
+    private GitLabUser resolvedBy;
+
+    @JsonProperty("noteable_iid")
+    private Integer noteableIid;
+
+    public Integer getId() {
+        return id;
+    }
+
+    public void setId(Integer id) {
+        this.id = id;
+    }
+
+    public String getBody() {
+        return body;
+    }
+
+    public void setBody(String body) {
+        this.body = body;
+    }
+
+    public GitLabUser getAuthor() {
+        return author;
+    }
+
+    public void setAuthor(GitLabUser author) {
+        this.author = author;
+    }
+
+    public Date getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(Date createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    public String getAttachment() {
+        return attachment;
+    }
+
+    public void setAttachment(String attachment) {
+        this.attachment = attachment;
+    }
+
+    public boolean isSystem() {
+        return system;
+    }
+
+    public void setSystem(boolean system) {
+        this.system = system;
+    }
+
+    public boolean isUpvote() {
+        return upvote;
+    }
+
+    public void setUpvote(boolean upvote) {
+        this.upvote = upvote;
+    }
+
+    public boolean isDownvote() {
+        return downvote;
+    }
+
+    public void setDownvote(boolean downvote) {
+        this.downvote = downvote;
+    }
+
+    public GitlabPosition getPosition() {
+        return position;
+    }
+
+    public void setPosition(GitlabPosition position) {
+        this.position = position;
+    }
+
+    public Integer getNoteableId() {
+        return noteableId;
+    }
+
+    public void setNoteableId(Integer noteableId) {
+        this.noteableId = noteableId;
+    }
+
+    public String getNoteable_type() {
+        return noteable_type;
+    }
+
+    public void setNoteable_type(String noteable_type) {
+        this.noteable_type = noteable_type;
+    }
+
+    public boolean isResolvable() {
+        return resolvable;
+    }
+
+    public void setResolvable(boolean resolvable) {
+        this.resolvable = resolvable;
+    }
+
+    public boolean isResolved() {
+        return resolved;
+    }
+
+    public void setResolved(boolean resolved) {
+        this.resolved = resolved;
+    }
+
+    public GitLabUser getResolvedBy() {
+        return resolvedBy;
+    }
+
+    public void setResolvedBy(GitLabUser resolvedBy) {
+        this.resolvedBy = resolvedBy;
+    }
+
+    public Integer getNoteableIid() {
+        return noteableIid;
+    }
+
+    public void setNoteableIid(Integer noteableIid) {
+        this.noteableIid = noteableIid;
+    }
+}

--- a/src/main/java/com/talanlabs/sonar/plugins/gitlab/api/GitlabPosition.java
+++ b/src/main/java/com/talanlabs/sonar/plugins/gitlab/api/GitlabPosition.java
@@ -1,0 +1,152 @@
+/*
+ * SonarQube :: GitLab Plugin
+ * Copyright (C) 2016-2017 Talanlabs
+ * gabriel.allaigre@gmail.com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.talanlabs.sonar.plugins.gitlab.api;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class GitlabPosition {
+  
+
+    @JsonProperty("base_sha")
+    private String baseSha;
+
+    @JsonProperty("start_sha")
+    private String startSha;
+
+    @JsonProperty("head_sha")
+    private String headSha;
+
+    @JsonProperty("position_type")
+    private String positionType;
+
+    @JsonProperty("new_path")
+    private String newPath;
+
+    @JsonProperty("new_line")
+    private Integer newLine;
+
+    @JsonProperty("old_path")
+    private String oldPath;
+
+    @JsonProperty("old_line")
+    private Integer oldLine;
+
+    private Integer width;
+    private Integer height;
+    private Integer x;
+    private Integer y;
+
+    public String getBaseSha() {
+        return baseSha;
+    }
+
+    public void setBaseSha(String baseSha) {
+        this.baseSha = baseSha;
+    }
+
+    public String getStartSha() {
+        return startSha;
+    }
+
+    public void setStartSha(String startSha) {
+        this.startSha = startSha;
+    }
+
+    public String getHeadSha() {
+        return headSha;
+    }
+
+    public void setHeadSha(String headSha) {
+        this.headSha = headSha;
+    }
+
+    public String getPositionType() {
+        return positionType;
+    }
+
+    public void setPositionType(String positionType) {
+        this.positionType = positionType;
+    }
+
+    public String getNewPath() {
+        return newPath;
+    }
+
+    public void setNewPath(String newPath) {
+        this.newPath = newPath;
+    }
+
+    public Integer getNewLine() {
+        return newLine;
+    }
+
+    public void setNewLine(Integer newLine) {
+        this.newLine = newLine;
+    }
+
+    public String getOldPath() {
+        return oldPath;
+    }
+
+    public void setOldPath(String oldPath) {
+        this.oldPath = oldPath;
+    }
+
+    public Integer getOldLine() {
+        return oldLine;
+    }
+
+    public void setOldLine(Integer oldLine) {
+        this.oldLine = oldLine;
+    }
+
+    public Integer getWidth() {
+        return width;
+    }
+
+    public void setWidth(Integer width) {
+        this.width = width;
+    }
+
+    public Integer getHeight() {
+        return height;
+    }
+
+    public void setHeight(Integer height) {
+        this.height = height;
+    }
+
+    public Integer getX() {
+        return x;
+    }
+
+    public void setX(Integer x) {
+        this.x = x;
+    }
+
+    public Integer getY() {
+        return y;
+    }
+
+    public void setY(Integer y) {
+        this.y = y;
+    }
+}
+

--- a/src/test/java/com/talanlabs/sonar/plugins/gitlab/GitLabApiV4WrapperTest.java
+++ b/src/test/java/com/talanlabs/sonar/plugins/gitlab/GitLabApiV4WrapperTest.java
@@ -26,6 +26,8 @@ import com.talanlabs.gitlab.api.v4.models.projects.GitLabProject;
 import com.talanlabs.gitlab.api.v4.services.GitLabAPICommits;
 import com.talanlabs.gitlab.api.v4.services.GitLabAPIMergeRequestDiff;
 import com.talanlabs.gitlab.api.v4.services.GitLabAPIMergeRequestDiscussion;
+import com.talanlabs.sonar.plugins.gitlab.api.GitLabAPIMergeRequestDiscussionExt;
+
 import org.junit.Test;
 import org.mockito.Matchers;
 
@@ -231,7 +233,12 @@ public class GitLabApiV4WrapperTest {
         GitLabProject gitLabProject = mock(GitLabProject.class);
         when(gitLabProject.getId()).thenReturn(projectId);
         facade.setGitLabProject(gitLabProject);
-
+        
+        GitLabAPIMergeRequestDiscussionExt gitLabAPIExt = mock(GitLabAPIMergeRequestDiscussionExt.class);
+        facade.setGitLabAPIExt(gitLabAPIExt);
+              
+        when(gitLabAPIExt.hasDiscussion(anyInt(), anyInt(), anyString(), anyInt(), anyString(), anyString(), anyString())).thenReturn(false);
+        
         GitLabAPIMergeRequestDiscussion mergeRequestDiscussion = mock(GitLabAPIMergeRequestDiscussion.class);
         when(gitLabAPI.getGitLabAPIMergeRequestDiscussion()).thenReturn(mergeRequestDiscussion);
 


### PR DESCRIPTION
Changes: check existing issue threads, get pull request analysis issues instead of branch when sonar scan is done on pull request (sonar.pullrequestKey arg)