### PR TITLE
Ignore sonar.gitlab.merge_request_discussion in branch analyses

### DIFF
--- a/src/main/java/com/talanlabs/sonar/plugins/gitlab/GitLabApiV4Wrapper.java
+++ b/src/main/java/com/talanlabs/sonar/plugins/gitlab/GitLabApiV4Wrapper.java
@@ -283,7 +283,7 @@ public class GitLabApiV4Wrapper implements IGitLabApiWrapper {
     @Override
     public void createOrUpdateReviewComment(String revision, String fullPath, Integer line, String body) {
         try {
-            if (config.isMergeRequestDiscussionEnabled()) {
+            if (config.isMergeRequestDiscussionEnabled() && config.mergeRequestIid() != -1) {
                 createReviewDiscussion(fullPath, line, body);
             } else {
                 gitLabAPIV4.getGitLabAPICommits().postCommitComments(gitLabProject.getId(), revision != null ? revision : getFirstCommitSHA(), body, fullPath, line, "new");


### PR DESCRIPTION
`sonar.gitlab.merge_request_discussion` config parameter
should be used only for merge request analysis and ignored in other
analyses.