### PR TITLE
Throw exception on quality gate fail/error status at plugin level instead of sonar scanner

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -36,8 +36,9 @@ publish_job:
       - ci_settings.xml
   script:
     - |
-      mvn --quiet deploy:deploy-file -s gitlab_settings.xml -DpomFile=pom.xml \
-                              -Dfile=target/sonar-gitlab-plugin-*.jar \
+      jarfile=$(ls target/sonar-gitlab-plugin*.jar)
+      mvn deploy:deploy-file -s gitlab_settings.xml -DpomFile=pom.xml \
+                              -Dfile=${jarfile} \
                               -DrepositoryId=gitlab-maven \
                               -Durl=${CI_API_V4_URL}/projects/${CI_PROJECT_ID}/packages/maven
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,46 +1,66 @@
 image: maven:3.3.3-jdk-8
+
+workflow:
+  rules:
+    - if: '$CI_PIPELINE_SOURCE == "merge_request_event"'
+    - if: $CI_COMMIT_BRANCH && $CI_OPEN_MERGE_REQUESTS && $CI_PIPELINE_SOURCE == "push"
+      when: never
+    - if: $CI_COMMIT_BRANCH
+
 stages:
   - build
+  - publish
   - test
   - deploy
+
 build_job:
   stage: build
-  only:
-    - master
   script:
-    - mvn --batch-mode compile -Dmaven.test.skip=true -Djacoco.skip=true
+    - mvn --quiet clean package
+  cache:
+    key: maven
+    paths:
+      - .m2/repository
+  artifacts:
+    paths:
+      - target/*.jar
   tags:
     - docker
-build_merge_job:
-  stage: build
-  except:
-    - master
-    - tags
+
+publish_job:
+  stage: publish
+  dependencies:
+    - build_job
+  artifacts:
+    paths:
+      - ci_settings.xml
   script:
-    - git merge origin master --no-commit --no-ff
-    - mvn --batch-mode compile -Dmaven.test.skip=true -Djacoco.skip=true
-  tags:
-    - docker
+    - |
+      mvn --quiet deploy:deploy-file -s gitlab_settings.xml -DpomFile=pom.xml \
+                              -Dfile=target/sonar-gitlab-plugin-*.jar \
+                              -DrepositoryId=gitlab-maven \
+                              -Durl=${CI_API_V4_URL}/projects/${CI_PROJECT_ID}/packages/maven
+
 test_sonar_preview_job:
   stage: test
   except:
     - master
     - tags
   script:
-    - git merge origin master --no-commit --no-ff
     - mvn --batch-mode verify org.sonarsource.scanner.maven:sonar-maven-plugin:3.4.0.905:sonar -Dsonar.host.url=$SONAR_URL -Dsonar.login=$SONAR_LOGIN -Dsonar.analysis.mode=preview -Dsonar.gitlab.commit_sha=$CI_COMMIT_SHA -Dsonar.gitlab.ref_name=$CI_COMMIT_REF_NAME -Dsonar.gitlab.project_id=$CI_PROJECT_ID
   tags:
     - docker
+
 test_sonar_feature_job:
   stage: test
   except:
     - master
     - tags
   script:
-    - git merge origin master --no-commit --no-ff
     - mvn --batch-mode verify org.sonarsource.scanner.maven:sonar-maven-plugin:3.4.0.905:sonar -Dsonar.host.url=$SONAR_OFF_URL -Dsonar.login=$SONAR_OFF_LOGIN -Dsonar.branch.name=$CI_COMMIT_REF_NAME
   tags:
     - docker
+
 test_sonar_job:
   stage: test
   only:

--- a/README.md
+++ b/README.md
@@ -7,6 +7,9 @@ Inspired by https://github.com/SonarCommunity/sonar-github
 
 # Current version
 
+## Version 5.1.3
+
+ * merged [Throw exception on quality gate fail/error](https://github.com/javamachr/sonar-gitlab-plugin/pull/24)
 
 ## Version 5.1.2
 

--- a/README.md
+++ b/README.md
@@ -338,6 +338,7 @@ https://docs.gitlab.com/ce/ci/variables/#9-0-renaming
 | sonar.gitlab.disable_proxy | Disable proxy if system contains proxy config (default false) | Administration, Variable | >= 4.0.0 |
 | sonar.gitlab.merge_request_discussion | Allows to post the comments as discussions (default false) | Project, Variable | >= 4.0.0 |
 | sonar.gitlab.ci_merge_request_iid | The IID of the merge request if it’s pipelines for merge requests | Project, Variable | >= 4.0.0 |
+| sonar.gitlab.fail_on_qualitygate | Fail scan if the quality gate fails (default false), this is required to fail the scanner since the plugin requires the `sonar.qualitygate.wait=false` to run | Project, Variable | >= 5.0.2 |
 
 - Administration : **Settings** globals in SonarQube
 - Project : **Settings** of project in SonarQube

--- a/gitlab_settings.xml
+++ b/gitlab_settings.xml
@@ -1,0 +1,16 @@
+<settings xmlns="http://maven.apache.org/SETTINGS/1.1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.1.0 http://maven.apache.org/xsd/settings-1.1.0.xsd">
+    <servers>
+    <server>
+        <id>gitlab-maven</id>
+        <configuration>
+        <httpHeaders>
+            <property>
+            <name>Job-Token</name>
+            <value>${CI_JOB_TOKEN}</value>
+            </property>
+        </httpHeaders>
+        </configuration>
+    </server>
+    </servers>
+</settings>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
   </parent>
   <groupId>com.talanlabs</groupId>
   <artifactId>sonar-gitlab-plugin</artifactId>
-  <version>5.1.2</version>
+  <version>5.1.3</version>
   <name>SonarQube :: GitLab Plugin</name>
   <description>GitLab Plugin for Reporting</description>
   <packaging>sonar-plugin</packaging>

--- a/src/main/java/com/talanlabs/sonar/plugins/gitlab/CommitPublishPostJob.java
+++ b/src/main/java/com/talanlabs/sonar/plugins/gitlab/CommitPublishPostJob.java
@@ -98,6 +98,12 @@ public class CommitPublishPostJob implements PostJob {
 
             Reporter report = reporterBuilder.build(qualityGate, issues);
             notification(report);
+
+            if(gitLabPluginConfiguration.failOnQualityGate() && QualityGate.Status.ERROR.equals(qualityGate.getStatus()))
+            {
+                throw MessageException.of("Quality Gate failed. Exiting scan with failure.");
+            }
+
         } catch (MessageException e) {
             StatusNotificationsMode i = gitLabPluginConfiguration.statusNotificationsMode();
             if (i == StatusNotificationsMode.COMMIT_STATUS) {

--- a/src/main/java/com/talanlabs/sonar/plugins/gitlab/GitLabPlugin.java
+++ b/src/main/java/com/talanlabs/sonar/plugins/gitlab/GitLabPlugin.java
@@ -69,6 +69,7 @@ public class GitLabPlugin implements Plugin {
     public static final String GITLAB_MERGE_REQUEST_DISCUSSION = "sonar.gitlab.merge_request_discussion";
     public static final String GITLAB_CI_MERGE_REQUEST_IID = "sonar.gitlab.ci_merge_request_iid";
     public static final String SONAR_PULL_REQUEST_KEY = "sonar.pullrequest.key";
+    public static final String GITLAB_FAIL_ON_QUALITY_GATE = "sonar.gitlab.fail_on_qualitygate";
 
     public static final String CATEGORY = "gitlab";
     public static final String SUBCATEGORY = "reporting";
@@ -166,7 +167,11 @@ public class GitLabPlugin implements Plugin {
                         PropertyDefinition.builder(GITLAB_CI_MERGE_REQUEST_IID).name("Merge Request IID").description("The IID of the merge request if it’s pipelines for merge requests")
                                 .category(CATEGORY).subCategory(SUBCATEGORY).type(PropertyType.INTEGER)
                                 .defaultValue(String.valueOf(-1))
-                                .index(35).build()
+                                .index(35).build(),
+                        PropertyDefinition.builder(GITLAB_FAIL_ON_QUALITY_GATE).name("Quality Gate fail").description("Fail the scan process based on quality gate error status")
+                                .category(CATEGORY).subCategory(SUBCATEGORY).type(PropertyType.BOOLEAN)
+                                .defaultValue(String.valueOf(false))
+                                .index(36).build()
 
                 );
     }

--- a/src/main/java/com/talanlabs/sonar/plugins/gitlab/GitLabPluginConfiguration.java
+++ b/src/main/java/com/talanlabs/sonar/plugins/gitlab/GitLabPluginConfiguration.java
@@ -280,5 +280,8 @@ public class GitLabPluginConfiguration {
         return configuration.getInt(GitLabPlugin.SONAR_PULL_REQUEST_KEY).orElse(-1);
     }
 
+    public boolean failOnQualityGate() {
+        return configuration.getBoolean(GitLabPlugin.GITLAB_FAIL_ON_QUALITY_GATE).orElse(false);
+    }
 
 }


### PR DESCRIPTION
1. > Since the plugin requires the sonar param sonar.qualitygate.wait=false to run in a fail case, where if it true the scan waits and fails before the plugin can run.
    > ref: [Failing a pipeline job when the Quality Gate fails](https://docs.sonarqube.org/latest/analysis/ci-integration-overview/#header-1)
    > 
    > Hence adding a parameter at plugin level to be able to run the plugin and still be able to fail the scan job.
2. > Update gitlab-ci with the latest.