### PR TITLE
Add minimum sonarqube version note for latest release

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ Inspired by https://github.com/SonarCommunity/sonar-github
 
 ## Version 5.1.3
 
+**Only SonarQube 9.3+ **
+
  * merged [Throw exception on quality gate fail/error](https://github.com/javamachr/sonar-gitlab-plugin/pull/24)
 
 ## Version 5.1.2


### PR DESCRIPTION
Hi,

since I bumped the sonarqube-api in #22, it turns out the plugin not longer works in SQ 8.9.

This PR add minimum sonarqube version note. Additionally, it should be considered going back to 8.9 to support the latest dependency.

Sorry I was not aware of this, that the sonar-plugin-api define the minimum supported sonarqube version.