### PR TITLE
Make the GitLab status name configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -350,6 +350,7 @@ https://docs.gitlab.com/ce/ci/variables/#9-0-renaming
 | sonar.gitlab.merge_request_discussion | Allows to post the comments as discussions (default false) | Project, Variable | >= 4.0.0 |
 | sonar.gitlab.ci_merge_request_iid | The IID of the merge request if it’s pipelines for merge requests | Project, Variable | >= 4.0.0 |
 | sonar.gitlab.fail_on_qualitygate | Fail scan if the quality gate fails (default false), this is required to fail the scanner since the plugin requires the `sonar.qualitygate.wait=false` to run | Project, Variable | >= 5.0.2 |
+| sonar.gitlab.status_name | The name of the commit status created by the plugin (default `sonarqube`) | Project, Variable | >= 5.2.2 |
 
 - Administration : **Settings** globals in SonarQube
 - Project : **Settings** of project in SonarQube

--- a/src/main/java/com/talanlabs/sonar/plugins/gitlab/GitLabApiV4Wrapper.java
+++ b/src/main/java/com/talanlabs/sonar/plugins/gitlab/GitLabApiV4Wrapper.java
@@ -45,8 +45,6 @@ public class GitLabApiV4Wrapper implements IGitLabApiWrapper {
 
     private static final Logger LOG = Loggers.get(GitLabApiV4Wrapper.class);
 
-    private static final String COMMIT_CONTEXT = "sonarqube";
-
     private final GitLabPluginConfiguration config;
     private GitLabAPI gitLabAPIV4;
     private GitLabProject gitLabProject;
@@ -220,7 +218,7 @@ public class GitLabApiV4Wrapper implements IGitLabApiWrapper {
     public void createOrUpdateSonarQubeStatus(String status, String statusDescription) {
         try {
             gitLabAPIV4.getGitLabAPICommits()
-                    .postCommitStatus(gitLabProject.getId(), getFirstCommitSHA(), status, config.refName(), COMMIT_CONTEXT, null, statusDescription);
+                    .postCommitStatus(gitLabProject.getId(), getFirstCommitSHA(), status, config.refName(), config.statusName(), null, statusDescription);
         } catch (IOException e) {
             // Workaround for https://gitlab.com/gitlab-org/gitlab-ce/issues/25807
             if (e.getMessage() != null && e.getMessage().contains("Cannot transition status")) {

--- a/src/main/java/com/talanlabs/sonar/plugins/gitlab/GitLabPlugin.java
+++ b/src/main/java/com/talanlabs/sonar/plugins/gitlab/GitLabPlugin.java
@@ -70,6 +70,7 @@ public class GitLabPlugin implements Plugin {
     public static final String GITLAB_CI_MERGE_REQUEST_IID = "sonar.gitlab.ci_merge_request_iid";
     public static final String SONAR_PULL_REQUEST_KEY = "sonar.pullrequest.key";
     public static final String GITLAB_FAIL_ON_QUALITY_GATE = "sonar.gitlab.fail_on_qualitygate";
+    public static final String GITLAB_STATUS_NAME = "sonar.gitlab.status_name";
 
     public static final String CATEGORY = "gitlab";
     public static final String SUBCATEGORY = "reporting";
@@ -171,7 +172,11 @@ public class GitLabPlugin implements Plugin {
                         PropertyDefinition.builder(GITLAB_FAIL_ON_QUALITY_GATE).name("Quality Gate fail").description("Fail the scan process based on quality gate error status")
                                 .category(CATEGORY).subCategory(SUBCATEGORY).type(PropertyType.BOOLEAN)
                                 .defaultValue(String.valueOf(false))
-                                .index(36).build()
+                                .index(36).build(),
+                        PropertyDefinition.builder(GITLAB_STATUS_NAME).name("GitLab status name").description("The name of the commit status created by the plugin.")
+                                .category(CATEGORY).subCategory(SUBCATEGORY)
+                                .defaultValue("sonarqube")
+                                .index(37).hidden().build()
 
                 );
     }

--- a/src/main/java/com/talanlabs/sonar/plugins/gitlab/GitLabPluginConfiguration.java
+++ b/src/main/java/com/talanlabs/sonar/plugins/gitlab/GitLabPluginConfiguration.java
@@ -284,4 +284,8 @@ public class GitLabPluginConfiguration {
         return configuration.getBoolean(GitLabPlugin.GITLAB_FAIL_ON_QUALITY_GATE).orElse(false);
     }
 
+    public String statusName()  {
+        return configuration.get(GitLabPlugin.GITLAB_STATUS_NAME).orElse("sonarqube");
+    }
+
 }

--- a/src/test/java/com/talanlabs/sonar/plugins/gitlab/GitLabApiV4WrapperTest.java
+++ b/src/test/java/com/talanlabs/sonar/plugins/gitlab/GitLabApiV4WrapperTest.java
@@ -61,6 +61,7 @@ public class GitLabApiV4WrapperTest {
         GitLabPluginConfiguration gitLabPluginConfiguration = mock(GitLabPluginConfiguration.class);
         when(gitLabPluginConfiguration.commitSHA()).thenReturn(Collections.singletonList("1"));
         when(gitLabPluginConfiguration.refName()).thenReturn("master");
+        when(gitLabPluginConfiguration.statusName()).thenReturn("sonarqube-1");
 
         GitLabApiV4Wrapper facade = new GitLabApiV4Wrapper(gitLabPluginConfiguration);
 
@@ -68,7 +69,7 @@ public class GitLabApiV4WrapperTest {
         facade.setGitLabAPI(gitLabAPI);
 
         GitLabAPICommits gitLabAPICommits = mock(GitLabAPICommits.class);
-        when(gitLabAPICommits.postCommitStatus(1, "1", "pending", "master", "sonarqube", "server", "")).thenReturn(null);
+        when(gitLabAPICommits.postCommitStatus(1, "1", "pending", "master", "sonarqube-1", "server", "")).thenReturn(null);
 
         when(gitLabAPI.getGitLabAPICommits()).thenReturn(gitLabAPICommits);
 
@@ -78,7 +79,7 @@ public class GitLabApiV4WrapperTest {
 
         facade.createOrUpdateSonarQubeStatus("pending", "nothing");
 
-        verify(gitLabAPICommits).postCommitStatus(1, "1", "pending", "master", "sonarqube", null, "nothing");
+        verify(gitLabAPICommits).postCommitStatus(1, "1", "pending", "master", "sonarqube-1", null, "nothing");
     }
 
     @Test
@@ -86,6 +87,7 @@ public class GitLabApiV4WrapperTest {
         GitLabPluginConfiguration gitLabPluginConfiguration = mock(GitLabPluginConfiguration.class);
         when(gitLabPluginConfiguration.commitSHA()).thenReturn(Collections.singletonList("1"));
         when(gitLabPluginConfiguration.refName()).thenReturn("master");
+        when(gitLabPluginConfiguration.statusName()).thenReturn("sonarqube-2");
 
         GitLabApiV4Wrapper facade = new GitLabApiV4Wrapper(gitLabPluginConfiguration);
 
@@ -93,7 +95,7 @@ public class GitLabApiV4WrapperTest {
         facade.setGitLabAPI(gitLabAPI);
 
         GitLabAPICommits gitLabAPICommits = mock(GitLabAPICommits.class);
-        when(gitLabAPICommits.postCommitStatus(1, "1", "pending", "master", "sonarqube", null, "nothing")).thenThrow(new IOException());
+        when(gitLabAPICommits.postCommitStatus(1, "1", "pending", "master", "sonarqube-2", null, "nothing")).thenThrow(new IOException());
 
         when(gitLabAPI.getGitLabAPICommits()).thenReturn(gitLabAPICommits);
 

--- a/src/test/java/com/talanlabs/sonar/plugins/gitlab/GitLabPluginConfigurationTest.java
+++ b/src/test/java/com/talanlabs/sonar/plugins/gitlab/GitLabPluginConfigurationTest.java
@@ -188,6 +188,10 @@ public class GitLabPluginConfigurationTest {
         Assertions.assertThat(config.isMergeRequestDiscussionEnabled()).isFalse();
         settings.setProperty(GitLabPlugin.GITLAB_MERGE_REQUEST_DISCUSSION, "true");
         Assertions.assertThat(config.isMergeRequestDiscussionEnabled()).isTrue();
+
+        Assertions.assertThat(config.statusName()).isEqualTo("sonarqube");
+        settings.setProperty(GitLabPlugin.GITLAB_STATUS_NAME, "sonar-analysis-1");
+        Assertions.assertThat(config.statusName()).isEqualTo("sonar-analysis-1");
     }
 
     @Test


### PR DESCRIPTION
#### Problem

Currently every commit status created by this plugin has the name `sonarqube`. This is fine as long as a project only has a single SonarQube analysis run on it. However, we would like to run multiple analyses and we would like these to create separate _external jobs_ in GitLab.

#### Solution

Create a new configuration option called `sonar.gitlab.status_name`. This allows us to configure the name of the created _external job_.